### PR TITLE
Suppress warnings from namespace conflicts

### DIFF
--- a/src/thurber.clj
+++ b/src/thurber.clj
@@ -1,4 +1,5 @@
 (ns thurber
+  (:refer-clojure :exclude [filter partial])
   (:require [camel-snake-kebab.core :as csk]
             [clojure.data.json :as json]
             [clojure.string :as str]


### PR DESCRIPTION
Suppress warnings from namespace conflicts.

```
WARNING: partial already refers to: #'clojure.core/partial in namespace: thurber, being replaced by: #'thurber/partial
WARNING: filter already refers to: #'clojure.core/filter in namespace: thurber, being replaced by: #'thurber/filter
```